### PR TITLE
Removed helper keys from the ui

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -5,15 +5,12 @@ import { parseToken, serializeToken } from '../utils/token'
 
 import {
   Container,
-  Section,
   Suggestions,
   Suggestion,
-  Helper,
   Operators,
   Operator,
   OperatorLone,
-  Key,
-  KeyOutline
+  Key
 } from './dropdown.styl'
 
 export default class extends PureComponent {
@@ -344,20 +341,6 @@ export default class extends PureComponent {
               {operator.name}
             </Operator>)}
         </Operators>
-
-        {this.props.keyboardHelpers &&
-          <Section center>
-            <Helper>
-              <KeyOutline>▲</KeyOutline>
-              <KeyOutline>▼</KeyOutline>
-              to navigate
-            </Helper>
-
-            <Helper>
-              <KeyOutline long>↵</KeyOutline>
-              to select
-            </Helper>
-          </Section>}
 
         <Footer />
       </Container>

--- a/src/components/dropdown.styl.js
+++ b/src/components/dropdown.styl.js
@@ -63,14 +63,6 @@ Container.defaultProps = {
   minWidth: '280px'
 }
 
-export const Section = styled.section`
-  padding: 15px;
-  text-align: ${props => props.center ? 'center' : 'inherit'};
-  :not(:last-child) {
-    border-bottom: 1px solid rgba(255, 255, 255, .15);
-  }
-`
-
 export const Suggestions = styled.ul`
   list-style-type: none;
   line-height: 20px;
@@ -105,8 +97,12 @@ Suggestion.defaultProps = {
   maxWidth: '320px'
 }
 
-export const Operators = Section.extend`
+export const Operators = styled.section`
   padding: 15px 0;
+  text-align: ${props => props.center ? 'center' : 'inherit'};
+  :not(:last-child) {
+    border-bottom: 1px solid rgba(255, 255, 255, .15);
+  }
 `
 
 export const Operator = styled.div`
@@ -138,22 +134,4 @@ export const Key = styled.div`
   vertical-align: middle;
   padding: 2px 5px;
   margin-right: 5px;
-`
-
-export const KeyOutline = Key.extend`
-  background: none;
-  border: 1px solid ${props => props.theme.color};
-  color: ${props => props.theme.color};
-  font-size: 8px;
-  padding: 0;
-  width: ${props => props.long ? '36px' : '18px'};
-  height: 18px;
-`
-
-export const Helper = styled.div`
-  display: inline-block;
-  opacity: 0.5;
-  &:not(:last-child) {
-    margin-right: 15px;
-  }
 `


### PR DESCRIPTION
Didn't feel like it was necessary to have them in there and they just took up space. It should be obvious what the up/down and enter keys will do.